### PR TITLE
Travis: Ruby 2.2, ruby-head を対象に追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1
+  - 2.2
+  - ruby-head


### PR DESCRIPTION
テスト対象に Ruby 2.2, ruby-head を追加。
ついでに Travis の container-based infrastructure を使用するようにした。