### PR TITLE
JpPrefecture::Prefecture.find(name: xxx)の挙動を修正

### DIFF
--- a/lib/jp_prefecture/prefecture.rb
+++ b/lib/jp_prefecture/prefecture.rb
@@ -115,6 +115,9 @@ module JpPrefecture
     # @return [Integer] 見つかった場合は都道府県コード
     # @return [nil] 見つからない場合は nil
     def self.find_code_by_name(name)
+      # nameがnil、空文字の場合は見つからないと判断してnilを返す。
+      return nil if name.nil? || name.empty?
+
       name = name.downcase
 
       Mapping.data.each do |m|

--- a/lib/jp_prefecture/prefecture.rb
+++ b/lib/jp_prefecture/prefecture.rb
@@ -115,7 +115,6 @@ module JpPrefecture
     # @return [Integer] 見つかった場合は都道府県コード
     # @return [nil] 見つからない場合は nil
     def self.find_code_by_name(name)
-      # nameがnil、空文字の場合は見つからないと判断してnilを返す。
       return nil if name.nil? || name.empty?
 
       name = name.downcase

--- a/spec/prefecture_spec.rb
+++ b/spec/prefecture_spec.rb
@@ -127,6 +127,20 @@ describe JpPrefecture::Prefecture do
           JpPrefecture::Prefecture.find(name: name)
           expect(name).to eq 'hokkaido'
         end
+
+        context '空の文字列が与えられた場合' do
+          it 'nilを返すこと' do
+            actual = JpPrefecture::Prefecture.find(name: '')
+            expect(actual).to be_nil
+          end
+        end
+
+        context 'nilが与えられた場合' do
+          it 'nilを返すこと' do
+            actual = JpPrefecture::Prefecture.find(name: nil)
+            expect(actual).to be_nil
+          end
+        end
       end
 
       context 'zip の場合' do


### PR DESCRIPTION
#18 のIssueに対する修正です。
引数に空文字、nilを与えた場合にnilを返すようにしました。
よろしくお願いしますm(_ _)m