### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           # Set to `TargetRubyVersion` in `.rubocop.yml`
-          ruby-version: 2.4
+          ruby-version: '2.4'
 
       - name: Bundle
         run: |
@@ -35,10 +35,11 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.4
-          - 2.5
-          - 2.6
-          - 2.7
+          - '2.4'
+          - '2.5'
+          - '2.6'
+          - '2.7'
+          - '3.0'
         gemfile:
           - rails50.gemfile
           - rails51.gemfile
@@ -46,14 +47,20 @@ jobs:
           - rails60.gemfile
           - rails61.gemfile
         exclude:
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: rails60.gemfile
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: rails61.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: rails60.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: rails61.gemfile
+          - ruby: '3.0'
+            gemfile: rails50.gemfile
+          - ruby: '3.0'
+            gemfile: rails51.gemfile
+          - ruby: '3.0'
+            gemfile: rails52.gemfile
 
     env:
       CI: true
@@ -70,7 +77,7 @@ jobs:
           sudo apt-get install libsqlite3-dev
 
       - name: Setup Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $ gem install jp_prefecture
 
 ## サポートしているバージョン
 
-* Ruby: 2.4 - 2.7
+* Ruby: 2.4 - 3.0
 * Rails: 5.0 - 6.1
 
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -184,7 +184,7 @@ $ gem install jp_prefecture
 
 ## Supports
 
-* Ruby: 2.4 - 2.7
+* Ruby: 2.4 - 3.0
 * Rails: 5.0 - 6.1
 
 


### PR DESCRIPTION
- Ruby 3.0 でテストを実行
- Ruby 3.0 と Rails 5.0 - 5.2 の組み合わせでテストが失敗するため exclude に指定