### PR TITLE
文字列による検索は項目を指定して検索する

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ require 'jp_prefecture'
 都道府県コードを渡すと、都道府県コードから都道府県を検索します:
 
 ```ruby
-pref = JpPrefecture::Prefecture.find 13
+pref = JpPrefecture::Prefecture.find(13)
 # => #<JpPrefecture::Prefecture:0x007fceb11927d8 @code=13, @name="東京都", @name_e="Tokyo", @name_h="とうきょうと", @name_k="トウキョウト", @zips=[1000000..2080035], @area="関東">
 pref.code
 # => 13
@@ -62,18 +62,27 @@ pref.type
 以下のように書くことも可能です:
 
 ```ruby
-JpPrefecture::Prefecture.find code: 13
+JpPrefecture::Prefecture.find(code: 13)
 ```
 
 ### 都道府県名から都道府県を検索
 
+前方一致で都道府県を検索します:
+
 ```ruby
-JpPrefecture::Prefecture.find name: "東京都"
-JpPrefecture::Prefecture.find name: "Tokyo"
-JpPrefecture::Prefecture.find name: "tokyo"
-JpPrefecture::Prefecture.find name: "トウキョウト"
-JpPrefecture::Prefecture.find name: "とうきょうと"
-JpPrefecture::Prefecture.find name: "東京"
+# 漢字表記
+JpPrefecture::Prefecture.find(name: "東京都")
+JpPrefecture::Prefecture.find(name: "東京")
+
+# 英語表記
+JpPrefecture::Prefecture.find(name_e: "Tokyo")
+JpPrefecture::Prefecture.find(name_e: "tokyo")
+
+# ひらがな表記
+JpPrefecture::Prefecture.find(name_h: "とうきょうと")
+
+# カタカナ表記
+JpPrefecture::Prefecture.find(name_k: "トウキョウト")
 ```
 
 ### 都道府県の一覧を取得
@@ -153,7 +162,7 @@ end
 custom_mapping_path = "..." # /path/to/mapping_data
 
 JpPrefecture.setup do |config|
-  config.mapping_data = YAML.load_file custom_mapping_path
+  config.mapping_data = YAML.load_file(custom_mapping_path)
 end
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -38,7 +38,7 @@ require 'jp_prefecture'
 Provide prefecture code to search prefecture's data
 
 ```ruby
-pref = JpPrefecture::Prefecture.find 13
+pref = JpPrefecture::Prefecture.find(13)
 # => #<JpPrefecture::Prefecture:0x007fceb11927d8 @code=13, @name="東京都", @name_e="Tokyo", @name_h="とうきょうと", @name_k="トウキョウト", @zips=[1000000..2080035], @area="関東">
 pref.code
 # => 13
@@ -59,18 +59,27 @@ pref.type
 or
 
 ```ruby
-JpPrefecture::Prefecture.find code: 13
+JpPrefecture::Prefecture.find(code: 13)
 ```
 
 ### Search by Prefecture Name
 
+Search for a prefecture by forward match.
+
 ```ruby
-JpPrefecture::Prefecture.find name: "東京都"
-JpPrefecture::Prefecture.find name: "Tokyo"
-JpPrefecture::Prefecture.find name: "tokyo"
-JpPrefecture::Prefecture.find name: "トウキョウト"
-JpPrefecture::Prefecture.find name: "とうきょうと"
-JpPrefecture::Prefecture.find name: "東京"
+# Kanji
+JpPrefecture::Prefecture.find(name: "東京都")
+JpPrefecture::Prefecture.find(name: "東京")
+
+# English
+JpPrefecture::Prefecture.find(name_e: "Tokyo")
+JpPrefecture::Prefecture.find(name_e: "tokyo")
+
+# Hiragana
+JpPrefecture::Prefecture.find(name_h: "とうきょうと")
+
+# Kakatana
+JpPrefecture::Prefecture.find(name_k: "トウキョウト")
 ```
 
 ### All Prefectures
@@ -150,7 +159,7 @@ Customize mapping data with `custom_mapping_path`.
 custom_mapping_path = "..." # /path/to/mapping_data
 
 JpPrefecture.setup do |config|
-  config.mapping_data = YAML.load_file custom_mapping_path
+  config.mapping_data = YAML.load_file(custom_mapping_path)
 end
 ```
 

--- a/lib/jp_prefecture/prefecture/finder.rb
+++ b/lib/jp_prefecture/prefecture/finder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'jp_prefecture/mapping'
+require 'jp_prefecture/zip_mapping'
+
+module JpPrefecture
+  class Prefecture
+    # 都道府県の検索を行うクラス
+    class Finder
+      def initialize
+        @mapping = Mapping.data
+      end
+
+      # 指定した項目を検索
+      #
+      # @param field [Symbol] 検索する項目。nil の場合は都道府県コードとして扱う
+      # @param value [String, Integer] 検索する内容
+      # @return [JpPrefecture::Prefecture] 都道府県が見つかった場合は都道府県クラス
+      # @return [nil] 都道府県が見つからない場合は nil
+      def find(field:, value:)
+        code = find_code(field, value)
+        prefecture = @mapping[code]
+        return unless prefecture
+
+        JpPrefecture::Prefecture.build(
+          code,
+          prefecture[:name],
+          prefecture[:name_e],
+          prefecture[:name_h],
+          prefecture[:name_k],
+          prefecture[:area]
+        )
+      end
+
+      private
+
+      # @param field [Symbol] 検索する項目
+      # @param value [String, Integer] 検索する内容
+      # @return [Integer] 見つかった場合は都道府県コード
+      # @return [nil] 見つからない場合は nil
+      def find_code(field, value)
+        return value.to_i if field.nil?
+
+        case field
+        when :all_fields
+          find_code_by_name_from_all_fields(value)
+        when :name, :name_h, :name_k, :name_e
+          find_code_by_name(field, value)
+        when :code
+          value.to_i
+        when :zip
+          ZipMapping.code_for_zip(value.to_i)
+        end
+      end
+
+      # すべての項目を前方一致で検索
+      def find_code_by_name_from_all_fields(value)
+        return if value.nil? || value.empty?
+
+        value = value.downcase
+
+        @mapping.each do |m|
+          m[1].each_value do |v|
+            return m[0] if v.start_with?(value)
+          end
+        end
+      end
+
+      # 指定した項目を前方一致で検索
+      def find_code_by_name(field, value)
+        return if value.nil? || value.empty?
+
+        value = value.downcase
+
+        @mapping.each do |m|
+          return m[0] if m[1][field].start_with?(value)
+        end
+      end
+    end
+  end
+end

--- a/spec/prefecture/finder_spec.rb
+++ b/spec/prefecture/finder_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe JpPrefecture::Prefecture::Finder do
+  describe '#find' do
+    shared_examples '都道府県が見つかる' do |field, value, expected_result|
+      let(:result) { JpPrefecture::Prefecture::Finder.new.find(field: field, value: value) }
+      it { expect(result.name).to eq(expected_result) }
+    end
+
+    shared_examples '都道府県が見つからない' do |field, value|
+      let(:result) { JpPrefecture::Prefecture::Finder.new.find(field: field, value: value) }
+      it { expect(result).to be_nil }
+    end
+
+    describe 'field に all_fields (すべての項目) を指定する' do
+      # area の「東北」が最初にマッチする
+      it_behaves_like '都道府県が見つかる', :all_fields, '東', '青森県'
+      it_behaves_like '都道府県が見つからない', :all_fields, '饂飩'
+    end
+
+    describe 'field に name (漢字表記) を指定する' do
+      it_behaves_like '都道府県が見つかる', :name, '北海道', '北海道'
+      it_behaves_like '都道府県が見つかる', :name, '東京', '東京都'
+      it_behaves_like '都道府県が見つかる', :name, '京都', '京都府'
+      it_behaves_like '都道府県が見つからない', :name, '饂飩'
+    end
+
+    describe 'field に name_e (英語表記) を指定する' do
+      it_behaves_like '都道府県が見つかる', :name_e, 'HOKKAIDO', '北海道'
+      it_behaves_like '都道府県が見つかる', :name_e, 'Hokkaido', '北海道'
+      it_behaves_like '都道府県が見つかる', :name_e, 'hokkaido', '北海道'
+      it_behaves_like '都道府県が見つからない', :name_e, 'Udon'
+    end
+
+    describe 'field に name_h (ひらがな表記) を指定する' do
+      it_behaves_like '都道府県が見つかる', :name_h, 'ほっかいどう', '北海道'
+      it_behaves_like '都道府県が見つかる', :name_h, 'ほっかい', '北海道'
+      it_behaves_like '都道府県が見つからない', :name_h, 'うどん'
+    end
+
+    describe 'field に name_k (カタカナ表記) を指定する' do
+      it_behaves_like '都道府県が見つかる', :name_k, 'ホッカイドウ', '北海道'
+      it_behaves_like '都道府県が見つかる', :name_k, 'ホッカイ', '北海道'
+      it_behaves_like '都道府県が見つからない', :name_k, 'ウドン'
+    end
+
+    describe 'field に code (都道府県コード) を指定する' do
+      it_behaves_like '都道府県が見つかる', :code, 1, '北海道'
+      it_behaves_like '都道府県が見つかる', :code, '1', '北海道'
+      it_behaves_like '都道府県が見つかる', :code, '01', '北海道'
+      it_behaves_like '都道府県が見つからない', :code, 999
+      it_behaves_like '都道府県が見つからない', :code, '999'
+    end
+
+    describe 'field に zip (郵便番号) を指定する' do
+      it_behaves_like '都道府県が見つかる', :zip, 10_000, '北海道'
+      it_behaves_like '都道府県が見つかる', :zip, '010000', '北海道'
+      it_behaves_like '都道府県が見つからない', :zip, 999_999
+      it_behaves_like '都道府県が見つからない', :zip, '999999'
+    end
+
+    describe 'field を指定しない' do
+      it_behaves_like '都道府県が見つかる', nil, 1, '北海道'
+      it_behaves_like '都道府県が見つかる', nil, '1', '北海道'
+      it_behaves_like '都道府県が見つかる', nil, '01', '北海道'
+      it_behaves_like '都道府県が見つからない', nil, 999
+      it_behaves_like '都道府県が見つからない', nil, '999'
+    end
+  end
+end

--- a/spec/prefecture_spec.rb
+++ b/spec/prefecture_spec.rb
@@ -25,160 +25,33 @@ describe JpPrefecture::Prefecture do
     it { expect(nil_type_pref.type).to eq nil }
   end
 
-  describe '.find' do
-    describe '検索結果について' do
-      shared_examples '都道府県が見つかる' do |arg|
-        let(:pref) { JpPrefecture::Prefecture.find(arg) }
-        it { expect(pref.code).to eq 1 }
-        it { expect(pref.name).to eq '北海道' }
-        it { expect(pref.name_e).to eq 'Hokkaido' }
-        it { expect(pref.name_h).to eq 'ほっかいどう' }
-        it { expect(pref.name_k).to eq 'ホッカイドウ' }
-        it { expect(pref.zips).to eq [10_000..70_895, 400_000..996_509] }
-        it { expect(pref.area).to eq '北海道' }
-        it { expect(pref.type).to eq '道' }
-      end
-
-      shared_examples '都道府県が見つからない' do |arg|
-        let(:pref) { JpPrefecture::Prefecture.find(arg) }
-        it { expect(pref).to be_nil }
-      end
-
-      describe '都道府県コード' do
-        it_behaves_like '都道府県が見つかる', 1
-        it_behaves_like '都道府県が見つからない', 99
-        it_behaves_like '都道府県が見つかる', '1'
-        it_behaves_like '都道府県が見つかる', '01'
-        it_behaves_like '都道府県が見つからない', '99'
-      end
-
-      describe '都道府県コード(キーワード引数)' do
-        it_behaves_like '都道府県が見つかる', code: 1
-        it_behaves_like '都道府県が見つからない', code: 99
-        it_behaves_like '都道府県が見つかる', code: '1'
-        it_behaves_like '都道府県が見つかる', code: '01'
-        it_behaves_like '都道府県が見つからない', code: '99'
-      end
-
-      describe '都道府県名' do
-        it_behaves_like '都道府県が見つかる', name: '北海道'
-        it_behaves_like '都道府県が見つからない', name: 'うどん県'
-      end
-
-      describe '都道府県名(英語表記)' do
-        it_behaves_like '都道府県が見つかる', name_e: 'Hokkaido'
-        it_behaves_like '都道府県が見つからない', name_e: 'Udon'
-      end
-
-      describe '都道府県名(英語表記-小文字)' do
-        it_behaves_like '都道府県が見つかる', name_e: 'hokkaido'
-        it_behaves_like '都道府県が見つからない', name_e: 'udon'
-      end
-
-      describe '都道府県名(ひらがな表記)' do
-        it_behaves_like '都道府県が見つかる', name_h: 'ほっかいどう'
-        it_behaves_like '都道府県が見つからない', name_h: 'うどん'
-      end
-
-      describe '都道府県名(カタカナ表記)' do
-        it_behaves_like '都道府県が見つかる', name_k: 'ホッカイドウ'
-        it_behaves_like '都道府県が見つからない', name_k: 'ウドン'
-      end
-
-      describe '都道府県名(前方一致)' do
-        let(:pref) { JpPrefecture::Prefecture.find(name: '東京') }
-        it { expect(pref.name).to eq '東京都' }
-
-        let(:pref2) { JpPrefecture::Prefecture.find(name: '京都') }
-        it { expect(pref2.name).to eq '京都府' }
-
-        context 'マッチする都道府県が複数あった場合' do
-          let(:pref) { JpPrefecture::Prefecture.find(name: '宮') }
-          it { expect(pref.name).to eq '宮城県' }
-        end
-
-        context 'マッチする都道府県が複数あった場合(英語表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name_e: 'miya') }
-          it { expect(pref.name_e).to eq 'Miyagi' }
-
-          let(:pref2) { JpPrefecture::Prefecture.find(name_e: 'Miya') }
-          it { expect(pref2.name_e).to eq 'Miyagi' }
-        end
-
-        context 'マッチする都道府県が複数あった場合(ひらがな表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name_h: 'みや') }
-          it { expect(pref.name_h).to eq 'みやぎけん' }
-        end
-
-        context 'マッチする都道府県が複数あった場合(カタカナ表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name_k: 'ミヤ') }
-          it { expect(pref.name_k).to eq 'ミヤギケン' }
-        end
-      end
-    end
-
-    describe 'all_fields' do
-      context '指定する場合' do
-        let(:pref) { JpPrefecture::Prefecture.find(all_fields: '東') }
-        # area の「東北」が最初にマッチする
-        it { expect(pref.name).to eq '青森県' }
-      end
-    end
-
-    describe '渡した変数について' do
-      context 'string の場合' do
-        it '値が変更されないこと' do
-          code = '1'
-          JpPrefecture::Prefecture.find(code)
-          expect(code).to eq '1'
-        end
-      end
-
-      context 'code が string の場合' do
-        it '値が変更されないこと' do
-          code = '1'
-          JpPrefecture::Prefecture.find(code: code)
-          expect(code).to eq '1'
-        end
-      end
-
-      context 'name の場合' do
-        it '値が変更されないこと' do
-          name = 'hokkaido'
-          JpPrefecture::Prefecture.find(name: name)
-          expect(name).to eq 'hokkaido'
-        end
-
-        context '空の文字列が与えられた場合' do
-          it 'nilを返すこと' do
-            actual = JpPrefecture::Prefecture.find(name: '')
-            expect(actual).to be_nil
-          end
-        end
-
-        context 'nilが与えられた場合' do
-          it 'nilを返すこと' do
-            actual = JpPrefecture::Prefecture.find(name: nil)
-            expect(actual).to be_nil
-          end
-        end
-      end
-
-      context 'zip の場合' do
-        it '値が変更されないこと' do
-          zip = '9999999'
-          JpPrefecture::Prefecture.find(zip: zip)
-          expect(zip).to eq '9999999'
-        end
-      end
-    end
-  end
-
   describe '.all' do
     let(:prefs) { JpPrefecture::Prefecture.all }
     it { expect(prefs.first).to be_an_instance_of(JpPrefecture::Prefecture) }
     it '都道府県の数が 47 であること' do
       expect(prefs.count).to eq 47
+    end
+  end
+
+  describe '.find' do
+    before do
+      finder = spy('finder')
+      allow(JpPrefecture::Prefecture::Finder).to receive(:new).and_return(finder)
+    end
+
+    context '引数に Integer を指定' do
+      before { JpPrefecture::Prefecture.find(1) }
+      it { expect(JpPrefecture::Prefecture::Finder.new).to have_received(:find).with(field: nil, value: 1) }
+    end
+
+    context '引数に Hash を指定' do
+      before { JpPrefecture::Prefecture.find(code: 1) }
+      it { expect(JpPrefecture::Prefecture::Finder.new).to have_received(:find).with(field: :code, value: 1) }
+    end
+
+    context '引数に nil を指定' do
+      let(:result) { JpPrefecture::Prefecture.find(nil) }
+      it { expect(result).to be_nil }
     end
   end
 end

--- a/spec/prefecture_spec.rb
+++ b/spec/prefecture_spec.rb
@@ -66,23 +66,23 @@ describe JpPrefecture::Prefecture do
       end
 
       describe '都道府県名(英語表記)' do
-        it_behaves_like '都道府県が見つかる', name: 'Hokkaido'
-        it_behaves_like '都道府県が見つからない', name: 'Udon'
+        it_behaves_like '都道府県が見つかる', name_e: 'Hokkaido'
+        it_behaves_like '都道府県が見つからない', name_e: 'Udon'
       end
 
       describe '都道府県名(英語表記-小文字)' do
-        it_behaves_like '都道府県が見つかる', name: 'hokkaido'
-        it_behaves_like '都道府県が見つからない', name: 'udon'
+        it_behaves_like '都道府県が見つかる', name_e: 'hokkaido'
+        it_behaves_like '都道府県が見つからない', name_e: 'udon'
       end
 
       describe '都道府県名(ひらがな表記)' do
-        it_behaves_like '都道府県が見つかる', name: 'ほっかいどう'
-        it_behaves_like '都道府県が見つからない', name: 'うどん'
+        it_behaves_like '都道府県が見つかる', name_h: 'ほっかいどう'
+        it_behaves_like '都道府県が見つからない', name_h: 'うどん'
       end
 
       describe '都道府県名(カタカナ表記)' do
-        it_behaves_like '都道府県が見つかる', name: 'ホッカイドウ'
-        it_behaves_like '都道府県が見つからない', name: 'ウドン'
+        it_behaves_like '都道府県が見つかる', name_k: 'ホッカイドウ'
+        it_behaves_like '都道府県が見つからない', name_k: 'ウドン'
       end
 
       describe '都道府県名(前方一致)' do
@@ -98,22 +98,30 @@ describe JpPrefecture::Prefecture do
         end
 
         context 'マッチする都道府県が複数あった場合(英語表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name: 'miya') }
+          let(:pref) { JpPrefecture::Prefecture.find(name_e: 'miya') }
           it { expect(pref.name_e).to eq 'Miyagi' }
 
-          let(:pref2) { JpPrefecture::Prefecture.find(name: 'Miya') }
+          let(:pref2) { JpPrefecture::Prefecture.find(name_e: 'Miya') }
           it { expect(pref2.name_e).to eq 'Miyagi' }
         end
 
         context 'マッチする都道府県が複数あった場合(ひらがな表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name: 'みや') }
+          let(:pref) { JpPrefecture::Prefecture.find(name_h: 'みや') }
           it { expect(pref.name_h).to eq 'みやぎけん' }
         end
 
         context 'マッチする都道府県が複数あった場合(カタカナ表記)' do
-          let(:pref) { JpPrefecture::Prefecture.find(name: 'ミヤ') }
+          let(:pref) { JpPrefecture::Prefecture.find(name_k: 'ミヤ') }
           it { expect(pref.name_k).to eq 'ミヤギケン' }
         end
+      end
+    end
+
+    describe 'all_fields' do
+      context '指定する場合' do
+        let(:pref) { JpPrefecture::Prefecture.find(all_fields: '東') }
+        # area の「東北」が最初にマッチする
+        it { expect(pref.name).to eq '青森県' }
       end
     end
 


### PR DESCRIPTION
- 文字列による検索は項目を指定して検索する
  - 例えば `find(name: "北海道")` は漢字表記の都道府県、`find(name_e: "Tokyo")` は英語表記の都道府県のみを検索する
  - 以前の挙動は、マッピングのすべての項目を検索していた。そのため #24 のように意図しない結果が取得される可能性がある。推奨はしないが、`find(all_fields: "東")` とすれば以前の挙動を利用できる
- 検索処理を `JpPrefecture::Prefecture::Finder` クラスに抽出

Issues: #24, #27