### PR TITLE
Add method to create prefecture from prefecture code

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,36 +6,20 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 23
-
 # Offense count: 9
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
   Max: 146
 
-# Offense count: 1
-# Configuration parameters: IgnoredMethods.
-Metrics/CyclomaticComplexity:
-  Max: 8
-
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
   Max: 18
 
-# Offense count: 1
-# Configuration parameters: CountKeywordArgs, MaxOptionalParameters.
-Metrics/ParameterLists:
-  Max: 6
-
 # Offense count: 2
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
-    - 'test/**/*'
     - 'lib/jp_prefecture.rb'
     - 'lib/jp_prefecture/base.rb'

--- a/lib/jp_prefecture/prefecture/finder.rb
+++ b/lib/jp_prefecture/prefecture/finder.rb
@@ -15,21 +15,11 @@ module JpPrefecture
       #
       # @param field [Symbol] 検索する項目。nil の場合は都道府県コードとして扱う
       # @param value [String, Integer] 検索する内容
-      # @return [JpPrefecture::Prefecture] 都道府県が見つかった場合は都道府県クラス
+      # @return [JpPrefecture::Prefecture] 都道府県が見つかった場合は都道府県インスタンス
       # @return [nil] 都道府県が見つからない場合は nil
       def find(field:, value:)
         code = find_code(field, value)
-        prefecture = @mapping[code]
-        return unless prefecture
-
-        JpPrefecture::Prefecture.build(
-          code,
-          prefecture[:name],
-          prefecture[:name_e],
-          prefecture[:name_h],
-          prefecture[:name_k],
-          prefecture[:area]
-        )
+        JpPrefecture::Prefecture.build_by_code(code)
       end
 
       private

--- a/spec/prefecture_spec.rb
+++ b/spec/prefecture_spec.rb
@@ -3,26 +3,24 @@
 require 'spec_helper'
 
 describe JpPrefecture::Prefecture do
-  describe '.build' do
-    let(:pref) { JpPrefecture::Prefecture.build(1, '北海道', 'Hokkaido', 'ほっかいどう', 'ホッカイドウ', '北海道') }
-    it { expect(pref.code).to eq 1 }
-    it { expect(pref.name).to eq '北海道' }
-    it { expect(pref.name_e).to eq 'Hokkaido' }
-    it { expect(pref.name_h).to eq 'ほっかいどう' }
-    it { expect(pref.name_k).to eq 'ホッカイドウ' }
-    it { expect(pref.zips).to eq [10_000..70_895, 400_000..996_509] }
-    it { expect(pref.area).to eq '北海道' }
-    it { expect(pref.type).to eq '道' }
+  describe '.build_by_code' do
+    context '都道府県が見つかる' do
+      let(:pref) { JpPrefecture::Prefecture.build_by_code(1) }
+      it { expect(pref).to be_an_instance_of(JpPrefecture::Prefecture) }
+      it { expect(pref.code).to eq(1) }
+      it { expect(pref.name).to eq('北海道') }
+      it { expect(pref.name_e).to eq('Hokkaido') }
+      it { expect(pref.name_h).to eq('ほっかいどう') }
+      it { expect(pref.name_k).to eq('ホッカイドウ') }
+      it { expect(pref.zips).to eq(JpPrefecture::ZipMapping.data[pref.code]) }
+      it { expect(pref.area).to eq('北海道') }
+      it { expect(pref.type).to eq('道') }
+    end
 
-    let(:nil_type_pref) { JpPrefecture::Prefecture.build(13, '東京', 'Tokyo', 'とうきょう', 'トウキョウ', '関東') }
-    it { expect(nil_type_pref.code).to eq 13 }
-    it { expect(nil_type_pref.name).to eq '東京' }
-    it { expect(nil_type_pref.name_e).to eq 'Tokyo' }
-    it { expect(nil_type_pref.name_h).to eq 'とうきょう' }
-    it { expect(nil_type_pref.name_k).to eq 'トウキョウ' }
-    it { expect(nil_type_pref.zips).to eq [1_000_000..2_080_035] }
-    it { expect(nil_type_pref.area).to eq '関東' }
-    it { expect(nil_type_pref.type).to eq nil }
+    context '都道府県が見つからない' do
+      let(:pref) { JpPrefecture::Prefecture.build_by_code(99) }
+      it { expect(pref).to be_nil }
+    end
   end
 
   describe '.all' do


### PR DESCRIPTION
- `build` メソッドを廃止
- 都道府県コードから都道府県インスタンスを作成する `build_by_id` メソッドを追加