### PR TITLE
Release v1.0.0.rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 1.0.0.beta1 (2021-MM-DD Unreleased)
+## 1.0.0.rc1 (2021-02-10)
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ $ gem install jp_prefecture
 * Ruby: 2.4 - 3.0
 * Rails: 5.0 - 6.1
 
+これより古い Ruby/Rails バージョンを使用する場合は、[`v0.11.0`](https://github.com/chocoby/jp_prefecture/tree/0.x) を利用してください。
 
 ## Contributing
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -210,6 +210,7 @@ $ gem install jp_prefecture
 * Ruby: 2.4 - 3.0
 * Rails: 5.0 - 6.1
 
+If you are using an older Ruby/Rails version, please use [`v0.11.0`](https://github.com/chocoby/jp_prefecture/tree/0.x).
 
 ## Contributing
 

--- a/lib/jp_prefecture/version.rb
+++ b/lib/jp_prefecture/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JpPrefecture
-  VERSION = '0.11.0'
+  VERSION = '1.0.0.rc1'
 end


### PR DESCRIPTION
- バージョンを `1.0.0.rc1` に更新
- README に古いバージョンを利用する場合の説明を追加