### PR TITLE
Remove temporarily disable RuboCop rule (Style/HashConversion)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,11 +52,7 @@ task :create_zip_code_data do
     prefectures_to_zip[code] << [r0, r1]
   end
 
-  # rubocop:disable Style/HashConversion
-  # https://github.com/rubocop-hq/rubocop/issues/9526
   prefectures_to_zip = Hash[*prefectures_to_zip.sort.flatten(1)]
-  # rubocop:enable Style/HashConversion
-
   # save result
   File.open('data/zip.yml', 'w') do |file|
     file.write "# { prefecture_code: [[from_zip_1, to_zip_1], [from_zip_2, to_zip_2], ...], ... }\n"

--- a/lib/jp_prefecture/zip_mapping.rb
+++ b/lib/jp_prefecture/zip_mapping.rb
@@ -7,10 +7,7 @@ module JpPrefecture
   module ZipMapping
     filepath = File.join(File.dirname(__FILE__), '../../data/zip.yml')
     @data = YAML.load_file(filepath)
-    # rubocop:disable Style/HashConversion
-    # https://github.com/rubocop-hq/rubocop/issues/9526
     @data = Hash[*@data.collect { |code, arr| [code, arr.collect { |zip_from, zip_to| zip_from..zip_to }] }.flatten(1)]
-    # rubocop:enable Style/HashConversion
 
     def self.data
       JpPrefecture.config.zip_mapping_data || @data


### PR DESCRIPTION
- https://github.com/chocoby/jp_prefecture/pull/52 で一時的に無効にしていた RuboCop のルール (`Style/HashConversion`) を削除