### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
+## 1.1.0 (2022-03-17)
+
 ### Features
 
+* 都道府県情報にローマ字表記を追加 (PR [#57](https://github.com/chocoby/jp_prefecture/pull/57)/[@sondh5](https://github.com/sondh5))
 * Ruby 3.1 をサポートに追加 (PR [#54](https://github.com/chocoby/jp_prefecture/pull/54)/[@chocoby](https://github.com/chocoby))
 * Rails 7.0 をサポート (PR [#55](https://github.com/chocoby/jp_prefecture/pull/55)/[@chocoby](https://github.com/chocoby))
 

--- a/jp_prefecture.gemspec
+++ b/jp_prefecture.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.version       = JpPrefecture::VERSION
   gem.required_ruby_version = '>= 2.4.0'
 
+  gem.metadata['rubygems_mfa_required'] = 'true'
+
   gem.add_development_dependency 'activerecord', '>= 5.0.0'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rake'

--- a/jp_prefecture.gemspec
+++ b/jp_prefecture.gemspec
@@ -3,8 +3,8 @@
 require File.expand_path('lib/jp_prefecture/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ['@chocoby']
-  gem.email         = ['chocoby@gmail.com']
+  gem.authors       = ['chocoby']
+  gem.email         = ['chocoby@himajin.dev']
   gem.summary       = 'Convert japan prefecture code into prefecture name'
   gem.description   = 'Convert japan prefecture code (JIS X 0402 based) into prefecture name.'
   gem.homepage      = 'https://github.com/chocoby/jp_prefecture'

--- a/jp_prefecture.gemspec
+++ b/jp_prefecture.gemspec
@@ -3,22 +3,24 @@
 require File.expand_path('lib/jp_prefecture/version', __dir__)
 
 Gem::Specification.new do |gem|
+  gem.name          = 'jp_prefecture'
+  gem.version       = JpPrefecture::VERSION
   gem.authors       = ['chocoby']
   gem.email         = ['chocoby@himajin.dev']
+
   gem.summary       = 'Convert japan prefecture code into prefecture name'
   gem.description   = 'Convert japan prefecture code (JIS X 0402 based) into prefecture name.'
   gem.homepage      = 'https://github.com/chocoby/jp_prefecture'
   gem.license       = 'MIT'
 
+  gem.required_ruby_version = '>= 2.4'
+
+  gem.metadata['rubygems_mfa_required'] = 'true'
+
   gem.files         = Dir['{data,lib}/**/*', 'CHANGELOG.md', 'LICENSE', 'README.md', 'README_EN.md']
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = 'jp_prefecture'
   gem.require_paths = ['lib']
-  gem.version       = JpPrefecture::VERSION
-  gem.required_ruby_version = '>= 2.4.0'
-
-  gem.metadata['rubygems_mfa_required'] = 'true'
 
   gem.add_development_dependency 'activerecord', '>= 5.0.0'
   gem.add_development_dependency 'appraisal'

--- a/lib/jp_prefecture/version.rb
+++ b/lib/jp_prefecture/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JpPrefecture
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
- バージョンを `1.1.0` に更新
- Gemspec の `metadata` に `rubygems_mfa_required` を指定 ([Link](https://guides.rubygems.org/mfa-requirement-opt-in/))
- Gemspec の `authors`, `email` を変更