### PR TITLE
Support Ruby 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         gemfile:
           - rails50.gemfile
           - rails51.gemfile
@@ -75,6 +76,12 @@ jobs:
             gemfile: rails51.gemfile
           - ruby: '3.1'
             gemfile: rails52.gemfile
+          - ruby: '3.2'
+            gemfile: rails50.gemfile
+          - ruby: '3.2'
+            gemfile: rails51.gemfile
+          - ruby: '3.2'
+            gemfile: rails52.gemfile
 
     env:
       CI: true
@@ -83,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup System
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,13 +96,10 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Bundle
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
+        run:  bundle install --jobs 4 --retry 3
 
       - name: Test
-        run: |
-          bundle exec rspec
+        run: bundle exec rspec
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,16 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           # Set to `TargetRubyVersion` in `.rubocop.yml`
-          ruby-version: '2.4'
+          ruby-version: '2.5'
 
       - name: Bundle
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
+        run: bundle install --jobs 4 --retry 3
 
       - name: Lint
         run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,11 @@ inherit_from: .rubocop_todo.yml
 # See https://docs.rubocop.org/rubocop/configuration
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Style/AsciiComments:
   Enabled: false

--- a/Appraisals
+++ b/Appraisals
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-appraise 'rails50' do
-  gem 'activerecord', '~> 5.0'
-  gem 'sqlite3', '< 1.4'
-end
+if RUBY_VERSION < '3.0.0'
+  appraise 'rails50' do
+    gem 'activerecord', '~> 5.0'
+    gem 'sqlite3', '< 1.4'
+  end
 
-appraise 'rails51' do
-  gem 'activerecord', '~> 5.1'
-  gem 'sqlite3', '< 1.4'
-end
+  appraise 'rails51' do
+    gem 'activerecord', '~> 5.1'
+    gem 'sqlite3', '< 1.4'
+  end
 
-appraise 'rails52' do
-  gem 'activerecord', '~> 5.2'
-  gem 'sqlite3', '< 1.4'
+  appraise 'rails52' do
+    gem 'activerecord', '~> 5.2'
+    gem 'sqlite3', '< 1.4'
+  end
 end
 
 if RUBY_VERSION >= '2.6.0'

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ $ gem install jp_prefecture
 
 ## ドキュメント
 
-[http://rdoc.info/github/chocoby/jp_prefecture/main/frames/index](http://rdoc.info/github/chocoby/jp_prefecture/main/frames/index)
+[https://rubydoc.info/gems/jp_prefecture](https://rubydoc.info/gems/jp_prefecture)
 
 ## サポートしているバージョン
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ gem install jp_prefecture
 
 ## サポートしているバージョン
 
-* Ruby: 2.4 - 3.1
+* Ruby: 2.4 - 3.2
 * Rails: 5.0 - 7.0
 
 これより古い Ruby/Rails バージョンを使用する場合は、[`v0.11.0`](https://github.com/chocoby/jp_prefecture/tree/0.x) を利用してください。

--- a/README_EN.md
+++ b/README_EN.md
@@ -219,7 +219,7 @@ $ gem install jp_prefecture
 
 ## Supported versions
 
-* Ruby: 2.4 - 3.1
+* Ruby: 2.4 - 3.2
 * Rails: 5.0 - 7.0
 
 If you are using an older Ruby/Rails version, please use [`v0.11.0`](https://github.com/chocoby/jp_prefecture/tree/0.x).

--- a/README_EN.md
+++ b/README_EN.md
@@ -215,7 +215,7 @@ $ gem install jp_prefecture
 
 ## Documentation
 
-[http://rdoc.info/github/chocoby/jp_prefecture/main/frames/index](http://rdoc.info/github/chocoby/jp_prefecture/main/frames/index)
+[https://rubydoc.info/gems/jp_prefecture](https://rubydoc.info/gems/jp_prefecture)
 
 ## Supported versions
 


### PR DESCRIPTION
- Ruby 3.2 でテストを実行
- RuboCop の Ruby 2.4 サポートが終了したため、`.rubocop.yml` の `TargetRubyVersion` を 2.5 に変更