### PR TITLE
Add explicit logger require for concurrent-ruby 1.3.5 compatibility

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ if ENV['CI']
 end
 
 require 'jp_prefecture'
+require 'logger'
 require 'active_record'
 
 RSpec.configure do |config|


### PR DESCRIPTION
concurrent-ruby 1.3.5 で `logger` の依存が削除されました。
結果、Rails 6.0, 6,1, 7.0 向けのテストが失敗するようになりました。

対応として、`spec_helper.rb` で Active Record の前に `logger` を `require` するように修正しました。

https://github.com/ruby-concurrency/concurrent-ruby/pull/1062
https://github.com/rails/rails/pull/54264

---

エラーログ:

```
An error occurred while loading ./spec/base_spec.rb.
Failure/Error: require 'active_record'

NameError:
  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
# ./spec/spec_helper.rb:15:in `require'
# ./spec/spec_helper.rb:[15](https://github.com/chocoby/jp_prefecture/actions/runs/12858523716/job/35847750939#step:6:16):in `<top (required)>'
# ./spec/base_spec.rb:3:in `require'
# ./spec/base_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/config_spec.rb.
Failure/Error: require 'active_record'
```