### PR TITLE
Change TargetRubyVersion to Ruby 2.7 supported by RuboCop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           # Set to `TargetRubyVersion` in `.rubocop.yml`
-          ruby-version: '2.5'
+          ruby-version: '2.7'
 
       - name: Bundle
         run: bundle install --jobs 4 --retry 3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ inherit_from: .rubocop_todo.yml
 #   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
   SuggestExtensions: false
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -10,6 +10,7 @@ describe JpPrefecture::Base do
           klass = Class.new(ActiveRecord::Base) do
             self.table_name = :places
             include JpPrefecture
+
             jp_prefecture :prefecture_code
           end
 
@@ -26,6 +27,7 @@ describe JpPrefecture::Base do
           klass = Class.new(ActiveRecord::Base) do
             self.table_name = :places
             include JpPrefecture
+
             jp_prefecture :prefecture_id
           end
 
@@ -44,6 +46,7 @@ describe JpPrefecture::Base do
           klass = Class.new(ActiveRecord::Base) do
             self.table_name = :places
             include JpPrefecture
+
             jp_prefecture :prefecture_code, method_name: :prefecture_method
           end
 
@@ -61,6 +64,7 @@ describe JpPrefecture::Base do
         Class.new(ActiveRecord::Base) do
           self.table_name = :places
           include JpPrefecture
+
           jp_prefecture :prefecture_code
         end
       end


### PR DESCRIPTION
これまで CI で Lint を実行する際に、Ruby 2.5 をインストールして RuboCop を実行していたが、エラーが発生するようになった。
[Compatibility :: RuboCop Docs](https://docs.rubocop.org/rubocop/compatibility.html) を確認したところ、RuboCop は Ruby 2.7 以上をサポートしているので、CI は Ruby 2.7 をインストールするように変更する。