### PR TITLE
Fix custom zip_mapping_data range search

### DIFF
--- a/lib/jp_prefecture/zip_mapping.rb
+++ b/lib/jp_prefecture/zip_mapping.rb
@@ -5,12 +5,21 @@ require 'yaml'
 module JpPrefecture
   # コードと郵便番号のマッピング
   module ZipMapping
+    # [from, to] のペア配列を Range へ変換する
+    def self.convert_to_ranges(data)
+      data.each_with_object({}) do |(code, pairs), ranges|
+        ranges[code] = pairs.collect { |zip_from, zip_to| zip_from..zip_to }
+      end
+    end
+
+    private_class_method :convert_to_ranges
+
     filepath = File.join(File.dirname(__FILE__), '../../data/zip.yml')
-    @data = YAML.load_file(filepath)
-    @data = Hash[*@data.collect { |code, arr| [code, arr.collect { |zip_from, zip_to| zip_from..zip_to }] }.flatten(1)]
+    @data = convert_to_ranges(YAML.load_file(filepath))
 
     def self.data
-      JpPrefecture.config.zip_mapping_data || @data
+      raw = JpPrefecture.config.zip_mapping_data
+      raw ? convert_to_ranges(raw) : @data
     end
 
     def self.code_for_zip(zip)

--- a/spec/zip_mapping_spec.rb
+++ b/spec/zip_mapping_spec.rb
@@ -8,4 +8,32 @@ describe JpPrefecture::ZipMapping do
       expect(described_class.data.count).to eq 47
     end
   end
+
+  describe '.code_for_zip' do
+    context 'カスタムの zip_mapping_data を設定したとき' do
+      before do
+        JpPrefecture.setup do |config|
+          config.zip_mapping_data = { 1 => [[10_000, 70_895]] }
+        end
+      end
+
+      after do
+        JpPrefecture.setup do |config|
+          config.zip_mapping_data = nil
+        end
+      end
+
+      it '範囲の端点を検索できること' do
+        expect(described_class.code_for_zip(10_000)).to eq 1
+      end
+
+      it '範囲内の郵便番号を検索できること' do
+        expect(described_class.code_for_zip(50_000)).to eq 1
+      end
+
+      it '範囲外の郵便番号は見つからないこと' do
+        expect(described_class.code_for_zip(80_000)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
- カスタム `config.zip_mapping_data` の範囲検索が端点しかヒットせず、範囲内の郵便番号がほぼ `nil` になっていた不具合を修正
- 内蔵データと違いカスタムデータの `[from, to]` が Range に変換されず生配列のままだった
- 変換ロジックを `convert_to_ranges` に切り出し、内蔵・カスタム共通の変換パスに統一
