### PR TITLE
Fix ken_all.zip download URL and update zip code data

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :create_zip_code_data do
   file_name = 'ken_all_utf8.csv'
 
   # download files
-  `curl -O https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip`
+  `curl -O https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip`
   `unzip ken_all.zip`
   `iconv -f sjis -t utf-8 ken_all.csv > #{file_name}`
   `rm ken_all.zip`

--- a/data/zip.yml
+++ b/data/zip.yml
@@ -1,5 +1,5 @@
 # { prefecture_code: [[from_zip_1, to_zip_1], [from_zip_2, to_zip_2], ...], ... }
-# Last updated: 2025-02-24 06:01:54 UTC
+# Last updated: 2026-07-22 09:48:04 UTC
 ---
 1:
 - - 10000


### PR DESCRIPTION
- `ken_all.zip` のダウンロード URL が 404 になっていたため、新しい URL に修正
- `rake create_zip_code_data` を実行して `data/zip.yml` を再生成 (差分はタイムスタンプのみで、レンジデータに変更はなし)
