### PR TITLE
fix: reference KEN_ALL.CSV with correct case so the rake task works on Linux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,9 @@ task :create_zip_code_data do
   # download files
   `curl -O https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip`
   `unzip ken_all.zip`
-  `iconv -f sjis -t utf-8 ken_all.csv > #{file_name}`
+  `iconv -f sjis -t utf-8 KEN_ALL.CSV > #{file_name}`
   `rm ken_all.zip`
-  `rm ken_all.csv`
+  `rm KEN_ALL.CSV`
 
   zips = []
 


### PR DESCRIPTION
## 概要

- `create_zip_code_data` タスクが Linux 上で失敗する問題を修正
- 日本郵便の `ken_all.zip` に含まれる CSV は `KEN_ALL.CSV` (大文字) だが、Rakefile は `ken_all.csv` (小文字) を参照していた
- macOS はファイル名の大文字小文字を区別しないためローカルでは動作していたが、大文字小文字を区別する Linux (GitHub Actions) では `iconv` がファイルを見つけられず失敗していた