### PR TITLE
Publish gem to RubyGems automatically on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  BUNDLE_RETRY: 3
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Verify that the tag matches the gem version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected="${TAG#v}"
+          actual="$(ruby -e 'require_relative "lib/jp_prefecture/version"; print JpPrefecture::VERSION')"
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Tag ${TAG} does not match JpPrefecture::VERSION (${actual})"
+            exit 1
+          fi
+          echo "Tag ${TAG} matches JpPrefecture::VERSION (${actual})"
+
+  lint:
+    needs: verify
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Set to `TargetRubyVersion` in `.rubocop.yml`
+          ruby-version: '2.7'
+          bundler-cache: true
+
+      - name: Lint
+        run: bundle exec rubocop
+
+  test:
+    needs: verify
+
+    runs-on: ubuntu-latest
+
+    env:
+      CI: true
+      BUNDLE_GEMFILE: gemfiles/rails-8-1.gemfile
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Test
+        run: bundle exec rspec
+
+  push:
+    needs: [lint, test]
+
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release
+      url: https://rubygems.org/gems/jp_prefecture
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'ruby'
+
+      - name: Configure RubyGems credentials
+        uses: rubygems/configure-rubygems-credentials@v2.1.0
+
+      - name: Build gem
+        run: gem build jp_prefecture.gemspec
+
+      - name: Push gem to RubyGems.org
+        run: gem push jp_prefecture-*.gem
+
+  update_release:
+    needs: push
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Fill in the release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${TAG#v}"
+          awk -v ver="$version" '
+            /^## / { found = ($2 == ver); next }
+            found
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::warning::No section for ${version} in CHANGELOG.md; falling back to generated notes"
+            gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$TAG" --jq '.body' > release-notes.md
+          fi
+          gh release edit "$TAG" --notes-file release-notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,18 +67,20 @@ bundle exec rubocop -A
 
 ## リリース手順
 
+gem の公開は GitHub Actions の `release` ワークフローが行います。ローカルで `gem push` を実行する必要はありません。
+
 1. `lib/jp_prefecture/version.rb` のバージョンを変更
    - バージョニングは [セマンティックバージョニング](https://semver.org/lang/ja/) に則る
-1. `CHANGELOG.md` を編集
+1. `CHANGELOG.md` の `## Unreleased` を `## X.Y.Z (YYYY-MM-DD)` に変更
+   - リリースノートはこの節の内容がそのまま使われる
 1. main ブランチに対して Pull Request を作成
    - CI がパスしたらマージ
-1. Gem をリリース
-   ```
-   gem build
-   gem push jp_prefecture-X.Y.Z.gem
-   ```
-1. [Releases](https://github.com/chocoby/jp_prefecture/releases) でリリースを作成
-   - 内容は `CHANGELOG.md` と同様
+1. [Releases](https://github.com/chocoby/jp_prefecture/releases) で新しいリリースを作成
+   - タグに `vX.Y.Z` を指定する。タグはこの操作で作成されるため、ローカルでタグを打つ必要はない
+   - **本文は空のまま Publish する**
+1. [Actions](https://github.com/chocoby/jp_prefecture/actions) で `release` environment の承認を行う
+   - 承認前にタグとバージョンの一致検証、RuboCop、RSpec が実行される
+   - 承認すると gem が RubyGems.org に公開され、その後リリースノートが `CHANGELOG.md` の内容で自動的に埋まる
 
 
 ## 都道府県の郵便番号データの更新


### PR DESCRIPTION
## 概要

Releases 画面でリリースを Publish したら、gem を RubyGems.org へ自動公開する `release` ワークフローを追加します。ローカルでの `gem push` は不要になります。

## 背景

gemspec で `rubygems_mfa_required = true` を設定しているため、API キーによる `gem push` は OTP を要求され CI から実行できません。そのため Trusted Publishing (OIDC) を使い、長期シークレットを GitHub に保存しない形にしています。

## 設計判断

- 公式アクション `rubygems/release-gem` は使っていません。内部で `bundle exec rake release` を実行してタグを自分で作ろうとし、Publish 時に作成済みのタグと衝突するためです。認証用の `rubygems/configure-rubygems-credentials` のみを使い、build と push は自前で書いています
- Release 本文は `CHANGELOG.md` の該当節で常に上書きします。`CHANGELOG.md` を唯一の情報源にするためです。該当節がない場合は GitHub の自動生成ノートにフォールバックします

## リリース手順の変更

1. `version.rb` と `CHANGELOG.md` を更新して main にマージ
2. Releases 画面で `vX.Y.Z` タグを指定し、本文は空のまま Publish
3. Actions で `release` environment を承認
