### PR TITLE
Fix exceptions when name searches receive non-String values

### DIFF
--- a/lib/jp_prefecture/prefecture.rb
+++ b/lib/jp_prefecture/prefecture.rb
@@ -92,7 +92,7 @@ module JpPrefecture
     # @param args [Hash<Symbol, Integer>] :code 都道府県コード
     # @param args [Hash<Symbol, String>] :name 漢字表記/:name_e 英語表記/:name_r ローマ字表記/:name_h ひらがな表記/:name_k カタカナ表記
     # @param args [Hash<Symbol, Integer>] :zip 郵便番号
-    # @param args [Hash<Symbol, (String, Integer)>] :all_fields マッピングに定義しているすべてのフィールドから検索
+    # @param args [Hash<Symbol, String>] :all_fields マッピングに定義しているすべてのフィールドから検索
     # @return [JpPrefecture::Prefecture] 都道府県が見つかった場合は都道府県インスタンス
     # @return [nil] 都道府県が見つからない場合は nil
     def self.find(args)

--- a/lib/jp_prefecture/prefecture/finder.rb
+++ b/lib/jp_prefecture/prefecture/finder.rb
@@ -33,9 +33,9 @@ module JpPrefecture
 
         case field
         when :all_fields
-          find_code_by_name_from_all_fields(value)
+          find_code_by_name_from_all_fields(value.to_s)
         when :name, :name_h, :name_k, :name_e, :name_r
-          find_code_by_name(field, value)
+          find_code_by_name(field, value.to_s)
         when :code
           value.to_i
         when :zip
@@ -45,9 +45,8 @@ module JpPrefecture
 
       # すべての項目を前方一致で検索
       def find_code_by_name_from_all_fields(value)
-        return if value.nil? || value.empty?
-
         value = value.downcase
+        return if value.empty?
 
         @mapping.each do |m|
           m[1].each_value do |v|
@@ -58,9 +57,8 @@ module JpPrefecture
 
       # 指定した項目を前方一致で検索
       def find_code_by_name(field, value)
-        return if value.nil? || value.empty?
-
         value = value.downcase
+        return if value.empty?
 
         @mapping.each do |m|
           return m[0] if m[1][field].start_with?(value)

--- a/spec/prefecture/finder_spec.rb
+++ b/spec/prefecture/finder_spec.rb
@@ -68,6 +68,16 @@ describe JpPrefecture::Prefecture::Finder do
       it_behaves_like '都道府県が見つからない', :zip, '999999'
     end
 
+    describe 'value に String 以外を指定する' do
+      it_behaves_like '都道府県が見つかる', :all_fields, :東, '青森県'
+      it_behaves_like '都道府県が見つかる', :name, :北海道, '北海道'
+      it_behaves_like '都道府県が見つかる', :name_e, :hokkaido, '北海道'
+      it_behaves_like '都道府県が見つからない', :all_fields, 13
+      it_behaves_like '都道府県が見つからない', :name, 1
+      it_behaves_like '都道府県が見つからない', :all_fields, nil
+      it_behaves_like '都道府県が見つからない', :name, nil
+    end
+
     describe 'field を指定しない' do
       it_behaves_like '都道府県が見つかる', nil, 1, '北海道'
       it_behaves_like '都道府県が見つかる', nil, '1', '北海道'


### PR DESCRIPTION
`JpPrefecture::Prefecture.find` のメソッドドキュメントの `all_fields` に Integer を許容すると書いていたが、実装は String 前提の `empty?` / `downcase` を呼ぶため例外になっていた。

- `find(all_fields: 13)` → NoMethodError
- `find(name: 1)` → NoMethodError
- `find(name_e: :hokkaido)` → TypeError

`find_code` の String 系の分岐で `value` を `to_s` して渡すようにした。

あわせて `JpPrefecture::Prefecture.find` のドキュメントから Integer を削除。マッピングの検索対象は `:name` / `:name_e` / `:name_r` / `:name_h` / `:name_k` / `:area` の 6 つで都道府県コードを含まないため、Integer を渡しても必ず nil になり実態と合っていなかった。

## 互換性

破壊的変更はない。これまで例外だった入力が nil または検索成功に変わる。

なお `find(code: :foo)` / `find(zip: :foo)` は `Symbol#to_i` がないため引き続き NoMethodError が発生する。数値系フィールドに Symbol を渡すのは想定外の使い方と判断し、今回は対象外としている。
