### PR TITLE
郵便番号データ更新ワークフローの判定結果をジョブサマリに表示

### DIFF
--- a/.github/workflows/update-zip-code-data.yml
+++ b/.github/workflows/update-zip-code-data.yml
@@ -35,10 +35,12 @@ jobs:
         # when deciding whether the data actually changed.
         run: |
           if git diff --quiet -I '^# Last updated:' -- data/zip.yml; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+            changed=false
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            changed=true
           fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "\`data/zip.yml\` changed: \`$changed\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create pull request
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
## 概要

update-zip-code-data workflow で、`data/zip.yml` に差分があったかどうかをジョブサマリに出力し、ログを開かずに確認できるようにした
